### PR TITLE
Feature/fake job success

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -178,7 +178,7 @@ func main() {
 	var srv = &gliderssh.Server{Addr: BABind}
 	srv.AddHostKey(HostKeySigner)
 
-	var sessionID atomic.Uint64
+	var sessionID atomic.Int64
 	srv.Handle(func(_s gliderssh.Session) {
 		var s = session{Session: _s, id: sessionID.Add(1)}
 

--- a/cmd/agent/session.go
+++ b/cmd/agent/session.go
@@ -163,6 +163,13 @@ func (s session) getJob(arg string) (job *queue.Job, found bool) {
 		return nil, false
 	}
 
+	// Allow fake jobs to get a response instead of an error so that automations
+	// that haven't accounted for "no job needed" responses don't fail
+	var noop = queue.NoOpJob()
+	if id == noop.ID() {
+		return noop, true
+	}
+
 	var j = JobRunner.GetJob(id)
 	if j == nil {
 		s.respond(StatusError, "Job not found", H{"job": H{"id": id}})
@@ -220,7 +227,7 @@ func (s session) getJobLogs(arg string) {
 }
 
 func (s session) respondNoJob() {
-	s.respond(StatusSuccess, "No-op: job is redundant or already completed", H{"job": H{"id": -1}})
+	s.respond(StatusSuccess, "No-op: job is redundant or already completed", H{"job": H{"id": queue.NoOpJob().ID()}})
 }
 
 func (s session) queueJob(command string, args ...string) {

--- a/cmd/agent/session.go
+++ b/cmd/agent/session.go
@@ -14,11 +14,11 @@ import (
 	"github.com/open-oni/oni-agent/internal/version"
 )
 
-var sessionID atomic.Uint64
+var sessionID atomic.Int64
 
 type session struct {
 	ssh.Session
-	id uint64
+	id int64
 }
 
 // Status is a string type the handler's "status" JSON may return
@@ -157,7 +157,7 @@ func (s session) purgeBatch(name string) {
 }
 
 func (s session) getJob(arg string) (job *queue.Job, found bool) {
-	var id, _ = strconv.ParseUint(arg, 10, 64)
+	var id, _ = strconv.ParseInt(arg, 10, 64)
 	if id == 0 {
 		s.respond(StatusError, fmt.Sprintf("%q is not a valid job id", arg), nil)
 		return nil, false

--- a/internal/queue/job.go
+++ b/internal/queue/job.go
@@ -23,7 +23,7 @@ const (
 
 // Job represents a single ONI management job to be run
 type Job struct {
-	id          uint64
+	id          int64
 	status      JobStatus
 	cmd         *exec.Cmd
 	args        []string
@@ -79,7 +79,7 @@ func (j *Job) wait() error {
 }
 
 // ID returns the job's assigned ID number
-func (j *Job) ID() uint64 {
+func (j *Job) ID() int64 {
 	return j.id
 }
 

--- a/internal/queue/job.go
+++ b/internal/queue/job.go
@@ -36,6 +36,25 @@ type Job struct {
 	pid         int
 }
 
+var noopJob = &Job{
+	id:          -1,
+	status:      StatusSuccessful,
+	cmd:         nil,
+	args:        nil,
+	queuedAt:    time.Now(),
+	startedAt:   time.Now(),
+	completedAt: time.Now(),
+	err:         nil,
+	stdout:      logstream.Stream{},
+	stderr:      logstream.Stream{},
+	pid:         -1,
+}
+
+// NoOpJob returns a job that does nothing and has a success status
+func NoOpJob() *Job {
+	return noopJob
+}
+
 // start creates the command with the given context, starting the command and
 // storing its pid and start time. After calling start, wait must then be
 // called to let the command finish and release resources.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -15,8 +15,8 @@ import (
 // Queue holds the list of ONI jobs we need to run
 type Queue struct {
 	m       sync.Mutex
-	seq     uint64
-	lookup  map[uint64]*Job
+	seq     int64
+	lookup  map[int64]*Job
 	binpath string
 	env     []string
 	queue   chan *Job
@@ -25,7 +25,7 @@ type Queue struct {
 // New provides a new job queue
 func New(oniPath string) *Queue {
 	var binpath = filepath.Join(oniPath, "manage.py")
-	var q = &Queue{lookup: make(map[uint64]*Job), queue: make(chan *Job, 1000), binpath: binpath}
+	var q = &Queue{lookup: make(map[int64]*Job), queue: make(chan *Job, 1000), binpath: binpath}
 
 	// We store the env vars needed to emulate Python's virtual environment,
 	// which essentially operates by setting three env vars. There's other stuff
@@ -59,7 +59,7 @@ func New(oniPath string) *Queue {
 
 // NewJob queues up a new ONI management command from the given args, and
 // returns the queued job's id
-func (q *Queue) NewJob(args ...string) uint64 {
+func (q *Queue) NewJob(args ...string) int64 {
 	q.m.Lock()
 	defer q.m.Unlock()
 
@@ -77,7 +77,7 @@ func (q *Queue) NewJob(args ...string) uint64 {
 }
 
 // GetJob returns a job by its id
-func (q *Queue) GetJob(id uint64) *Job {
+func (q *Queue) GetJob(id int64) *Job {
 	return q.lookup[id]
 }
 


### PR DESCRIPTION
Adds a "no-op" job that can be returned when callers request data for cases where a job wasn't necessary. Previously checking job status would just fail, meaning a double-call to purge a batch or load a batch would result in a failure even though things were in a good state.