### PR TITLE
Use slice args for Queue.NewJob and Queue.QueueJob

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -193,7 +193,7 @@ func main() {
 	// This functions as an on-startup sanity check to verify that the agent can
 	// in fact call ONI commands with its current configuration
 	slog.Info("Checking ONI install")
-	var j = JobRunner.NewJob("check")
+	var j = JobRunner.NewJob("ONI Check", []string{"check"})
 	j.Run(ctx)
 	switch j.Status() {
 	case queue.StatusSuccessful:

--- a/cmd/agent/session.go
+++ b/cmd/agent/session.go
@@ -191,7 +191,7 @@ func (s session) loadTitle() {
 		return
 	}
 
-	var j = JobRunner.NewJob("load_titles", dir)
+	var j = JobRunner.NewJob("Load title from MARC XML", []string{"load_titles", dir})
 	err = j.Run(context.Background())
 	if err != nil {
 		slog.Error("Error ingesting MARC XML", "path", fpath, "error", err)
@@ -226,7 +226,7 @@ func (s session) loadBatch(name string) {
 		s.respond(StatusError, fmt.Sprintf("%q cannot be loaded", name), H{"error": err.Error()})
 		return
 	}
-	s.queueJob("Load batch", "load_batch", batchPath)
+	s.queueJob("Load batch", "load_batch", []string{batchPath})
 }
 
 func (s session) purgeBatch(name string) {
@@ -241,7 +241,7 @@ func (s session) purgeBatch(name string) {
 		s.respondNoJob()
 		return
 	}
-	s.queueJob("Purge batch", "purge_batch", name)
+	s.queueJob("Purge batch", "purge_batch", []string{name})
 }
 
 func (s session) getJob(arg string) (job *queue.Job, found bool) {
@@ -320,9 +320,9 @@ func (s session) respondNoJob() {
 	s.respond(StatusSuccess, "No-op: job is redundant or already completed", H{"job": H{"id": queue.NoOpJob().ID()}})
 }
 
-func (s session) queueJob(name, command string, args ...string) {
+func (s session) queueJob(name, command string, args []string) {
 	var combined = append([]string{command}, args...)
-	var id = JobRunner.QueueJob(name, combined...)
+	var id = JobRunner.QueueJob(name, combined)
 
 	s.respond(StatusSuccess, "Job added to queue", H{"job": H{"id": id}})
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -60,7 +60,7 @@ func New(oniPath string) *Queue {
 }
 
 // NewJob returns a Job set up to call ONI with the given args
-func (q *Queue) NewJob(name string, args ...string) *Job {
+func (q *Queue) NewJob(name string, args []string) *Job {
 	q.m.Lock()
 	defer q.m.Unlock()
 
@@ -85,8 +85,8 @@ func (q *Queue) NewJob(name string, args ...string) *Job {
 
 // QueueJob queues up a new ONI management command from the given args, and
 // returns the queued job's id
-func (q *Queue) QueueJob(name string, args ...string) int64 {
-	var j = q.NewJob(name, args...)
+func (q *Queue) QueueJob(name string, args []string) int64 {
+	var j = q.NewJob(name, args)
 	j.queuedAt = time.Now()
 	q.queue <- j
 

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -57,7 +57,7 @@ func TestNewQueue(t *testing.T) {
 
 func TestJobLifecycle(t *testing.T) {
 	var q = getQ(t)
-	var j = q.NewJob("test job", "arg1", "arg2")
+	var j = q.NewJob("test job", []string{"arg1", "arg2"})
 
 	if j.Status() != StatusPending {
 		t.Errorf("expected status %s, got %s", StatusPending, j.Status())
@@ -79,7 +79,7 @@ func TestJobLifecycle(t *testing.T) {
 
 func TestQueueJob(t *testing.T) {
 	var q = getQ(t)
-	var jobID = q.QueueJob("test job", "arg1")
+	var jobID = q.QueueJob("test job", []string{"arg1"})
 
 	var j = q.GetJob(jobID)
 	if j == nil {
@@ -93,7 +93,7 @@ func TestQueueJob(t *testing.T) {
 
 func TestJobExecution_Success(t *testing.T) {
 	var q = getQ(t)
-	var j = q.NewJob("Test success", "succeed")
+	var j = q.NewJob("Test success", []string{"succeed"})
 	var err = j.Run(context.Background())
 
 	if err != nil {
@@ -112,7 +112,7 @@ func TestJobExecution_Success(t *testing.T) {
 
 func TestJobExecution_Fail(t *testing.T) {
 	var q = getQ(t)
-	var j = q.NewJob("Test failure", "fail")
+	var j = q.NewJob("Test failure", []string{"fail"})
 	var err = j.Run(context.Background())
 
 	if err == nil {
@@ -126,7 +126,7 @@ func TestJobExecution_Fail(t *testing.T) {
 
 func TestPurgeOldJobs(t *testing.T) {
 	var q = New("/opt/openoni")
-	var j = q.NewJob("test purge", "arg1")
+	var j = q.NewJob("test purge", []string{"arg1"})
 
 	var id = j.ID()
 	if q.GetJob(id) != j {
@@ -148,9 +148,9 @@ func TestPurgeOldJobs(t *testing.T) {
 
 func TestAllJobs(t *testing.T) {
 	var q = New("/opt/openoni")
-	var j1 = q.NewJob("job1", "arg1")
+	var j1 = q.NewJob("job1", []string{"arg1"})
 	j1.queuedAt = time.Now()
-	var j2 = q.NewJob("job2", "arg2")
+	var j2 = q.NewJob("job2", []string{"arg2"})
 	j2.queuedAt = j1.queuedAt.Add(-1 * time.Hour)
 
 	var jobs = q.AllJobs()


### PR DESCRIPTION
This makes things uglier, but catches errors that slipped past us in the recent changes where some calls to these functions were missing the new "name" argument.